### PR TITLE
Add haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,12 @@
+{
+  "classPath": "Sources",
+  "contributors": [ "dstrekelj" ],
+  "dependencies": { },
+  "description": "General purpose collision (intersection) detection library",
+  "name": "jolt",
+  "license": "Zlib",
+  "releasenote": "Initial release",
+  "tags": [ "game", "kha" ],
+  "url" : "https://github.com/dstrekelj/mokha/",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Closes #1 

---

Add `haxelib.json` file in preparation for the eventual release and distribution through [lib.haxe.org](http://lib.haxe.org).