### PR TITLE
Add shape debug drawing support

### DIFF
--- a/Sources/jolt/Painter.hx
+++ b/Sources/jolt/Painter.hx
@@ -1,0 +1,28 @@
+package jolt;
+
+import jolt.geom.Quad;
+import jolt.geom.Shape;
+import jolt.math.Vec2;
+
+class Painter {
+	public static function paintQuad(p : IPaint, q : Quad) : Void {
+		paintVertices(p, q.vertices);
+	}
+
+	public static function paintShape(p : IPaint, s : Shape) : Void {
+		paintVertices(p, s.vertices);
+	}
+
+	static function paintVertices(p : IPaint, v : Array<Vec2>) : Void {
+		var l = v.length;
+		while (--l >= 0) {
+			if (l-1 < 0) p.line(v[0], v[v.length-1]);
+			else p.line(v[l], v[l-1]);
+		}
+	}
+}
+
+interface IPaint {
+	function point(p : Vec2) : Void;
+	function line(a : Vec2, b : Vec2) : Void;
+}

--- a/Sources/jolt/geom/Circle.hx
+++ b/Sources/jolt/geom/Circle.hx
@@ -35,7 +35,7 @@ class Circle extends Shape {
 	}
 
 	@:noCompletion inline function get_origin() return vertices[0];
-	@:noCompletion inline function set_r(r) {
+	@:noCompletion inline function set_r(r : Float) : Float {
 		d = 2 * r;
 		return this.r = r;
 	}


### PR DESCRIPTION
Debug drawing for implemented shapes is made possible by the `Painter` class and the `IPaint` interface it defines. It expected of the user to implement `IPaint` and pass it to `Painter` methods, or use `Painter` as a static extension for the `IPaint` implementation.